### PR TITLE
register() fails if collection name is specified

### DIFF
--- a/nanomongo/document.py
+++ b/nanomongo/document.py
@@ -114,7 +114,7 @@ class Nanomongo(object):
         """
         self.set_client(client) if client else None
         self.set_db(db_string) if db_string else None
-        self.set_collection() if collection else None
+        self.set_collection(collection) if collection else None
         self.check_config()
         self.add_son_manipulator()
         # indexes

--- a/test/test_document.py
+++ b/test/test_document.py
@@ -208,6 +208,7 @@ class ClientTestCase(unittest.TestCase):
         m_count = len(Doc.get_collection().database.outgoing_copying_manipulators)
         self.assertEqual(1, m_count)
 
+        Doc2.register(client=client, db='nanotestdb', collection='doc2_collection')
 
 class MongoDocumentTestCase(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
I believe it's just a typo. Anyway the fix is quite trivial.
