### PR TITLE
Allow adding alternative client types

### DIFF
--- a/nanomongo/util.py
+++ b/nanomongo/util.py
@@ -5,19 +5,28 @@ import pymongo
 
 from .errors import ExtraFieldError, ValidationError
 
+ok_types = ()
+
+try:
+    import pymongo
+    ok_types += (pymongo.MongoClient, pymongo.MongoReplicaSetClient)
+    import motor
+    ok_types += (motor.MotorClient, motor.MotorReplicaSetClient)
+except ImportError as e:
+    if not ok_types:
+        raise e
 
 def valid_client(client):
-    """returns ``True`` if input is pymongo or motor client"""
-    ok_types = ()
-    try:
-        import pymongo
-        ok_types += (pymongo.MongoClient, pymongo.MongoReplicaSetClient)
-        import motor
-        ok_types += (motor.MotorClient, motor.MotorReplicaSetClient)
-    except ImportError as e:
-        if not ok_types:
-            raise e
+    """returns ``True`` if input is pymongo or motor client
+    or any client added with allow_client()"""
     return isinstance(client, ok_types)
+
+
+def allow_client(client_type):
+    """Allows another type to act as client type.
+    Intended for using with mock clients."""
+    global ok_types
+    ok_types += (client_type,)
 
 
 def valid_field(obj, field):

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -5,6 +5,7 @@ from nanomongo.field import Field
 from nanomongo.document import BaseDocument
 from nanomongo.util import (
     DotNotationMixin, valid_field, valid_client, RecordingDict, check_keys,
+    allow_client,
 )
 from nanomongo.errors import ValidationError
 
@@ -59,6 +60,14 @@ class HelperFuncionsTestCase(unittest.TestCase):
             Doc.find_one({'bar.moo': 42})
             self.assertTrue(3 == len(w) and 'has no field' in str(w[-1].message))
 
+    def test_allow_mock(self):
+        class MockClient():
+            pass
+
+        client = MockClient()
+        self.assertFalse(valid_client(client))
+        allow_client(MockClient)
+        self.assertTrue(valid_client(client))
 
 class RecordingDictTestCase(unittest.TestCase):
     def test_recording_dict(self):


### PR DESCRIPTION
In my case it's mongomock.MongoClient for unit testing.
