### PR TITLE
Text type cast

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,5 +9,7 @@ matrix:
 services: mongodb
 install:
   - pip install -r requirements.txt -r requirements-test.txt
-  - pip install motor
-script: nosetests --with-coverage --cover-package=nanomongo
+  - pip install motor pep8
+script:
+  - "pep8 --ignore=E501 ./nanomongo"
+  - "nosetests --with-coverage --cover-package=nanomongo"

--- a/nanomongo/document.py
+++ b/nanomongo/document.py
@@ -106,7 +106,17 @@ class Nanomongo(object):
         to the class we defined, see
         :class:`~nanomongo.util.NanomongoSONManipulator`
         """
-        manipulator = NanomongoSONManipulator(self.classref())
+        if six.PY2:  # unicode -> str implicit transform for binary_type (str) Fields
+            def str_transformer(unicode_str):
+                return unicode_str.encode('utf-8')
+
+            str_fields = filter(lambda (fname, field): six.binary_type == field.data_type,
+                                self.fields.items())
+            transforms = dict(map(lambda (fname, field): (fname, str_transformer), str_fields))
+        else:
+            transforms = None
+
+        manipulator = NanomongoSONManipulator(self.classref(), transforms=transforms)
         self.database.add_son_manipulator(manipulator)
 
     def register(self, client=None, db_string=None, collection=None):

--- a/nanomongo/document.py
+++ b/nanomongo/document.py
@@ -111,7 +111,7 @@ class Nanomongo(object):
                 return unicode_str.encode('utf-8')
 
             str_fields = ((fname, field) for fname, field in self.fields.items()
-                if six.binary_type == field.data_type)
+                          if six.binary_type == field.data_type)
             transforms = dict((fname, str_transformer) for fname, field in str_fields)
         else:
             transforms = None

--- a/nanomongo/document.py
+++ b/nanomongo/document.py
@@ -110,9 +110,9 @@ class Nanomongo(object):
             def str_transformer(unicode_str):
                 return unicode_str.encode('utf-8')
 
-            str_fields = filter(lambda (fname, field): six.binary_type == field.data_type,
-                                self.fields.items())
-            transforms = dict(map(lambda (fname, field): (fname, str_transformer), str_fields))
+            str_fields = ((fname, field) for fname, field in self.fields.items()
+                if six.binary_type == field.data_type)
+            transforms = dict((fname, str_transformer) for fname, field in str_fields)
         else:
             transforms = None
 

--- a/nanomongo/util.py
+++ b/nanomongo/util.py
@@ -216,13 +216,19 @@ class NanomongoSONManipulator(pymongo.son_manipulator.SONManipulator):
 
     JIRA: PYTHON-175 PYTHON-215
     """
-    def __init__(self, as_class):
+    def __init__(self, as_class, transforms=None):
         self.as_class = as_class
+        if transforms:
+            assert isinstance(transforms, dict), 'transforms must be a dict'
+            self.transforms = transforms
 
     def will_copy(self):
         return True
 
     def transform_outgoing(self, son, collection):
+        if hasattr(self, 'transforms'):
+            for field, transformer in self.transforms.items():
+                son[field] = transformer(son[field])
         try:
             return self.as_class(son)
         except ExtraFieldError:

--- a/test/test_document.py
+++ b/test/test_document.py
@@ -437,6 +437,7 @@ class MongoDocumentTestCase(unittest.TestCase):
         self.assertEqual(d['_id'], dd['_id'])
 
     @unittest.skipUnless(PYMONGO_OK, 'pymongo not installed or connection refused')
+    @unittest.skipUnless(six.PY2, 'test irrelevant on PY3')
     def test_string_types(self):
         """Test text type case (as mongodb-pymongo returned string type is always unicode)"""
         client = pymongo.MongoClient()


### PR DESCRIPTION
``pymongo`` always returns ``unicode`` strings which needs to be encoded to ``str`` for fields demanding that.