### PR TITLE
fix the check_spec incompatibility

### DIFF
--- a/nanomongo/document.py
+++ b/nanomongo/document.py
@@ -40,7 +40,7 @@ def ref_getter_maker(field_name, document_class=None):
                 raise UnsupportedOperation(err_str % (dbref, classes, field_name))
             cls = classes.pop()
         # we don't use dereference since BaseDocument.find_one handles type casting nicely
-        return cls.find_one(_id=dbref.id)
+        return cls.find_one(dbref.id)
     return ref_getter
 
 
@@ -362,14 +362,14 @@ your document class with client, db, collection.''' % cls
     @classmethod
     def find(cls, *args, **kwargs):
         """``pymongo.Collection().find`` wrapper for this document"""
-        if args:
+        if args and isinstance(args[0], dict):
             check_spec(cls, args[0])
         return cls.get_collection().find(*args, **kwargs)
 
     @classmethod
     def find_one(cls, *args, **kwargs):
         """``pymongo.Collection().find_one`` wrapper for this document"""
-        if args:
+        if args and isinstance(args[0], dict):
             check_spec(cls, args[0])
         return cls.get_collection().find_one(*args, **kwargs)
 

--- a/test/test_document.py
+++ b/test/test_document.py
@@ -275,16 +275,16 @@ class MongoDocumentTestCase(unittest.TestCase):
         self.assertEqual(d._id, d.insert())
         del d.bar  # unset
         d.save()
-        self.assertEqual(d, Doc.find_one({'_id': d._id}))
+        self.assertEqual(d, Doc.find_one(d._id))
         d.foo = six.u('new foo')
         d['bar'] = 1337
         d.moo = ['moo 0']
         d.save(atomic=True)
-        self.assertEqual(d, Doc.find_one({'_id': d._id}))
+        self.assertEqual(d, Doc.find_one(d._id))
         d.moo = []
         del d['bar']
         d.save()
-        self.assertEqual(d, Doc.find_one({'_id': d._id}))
+        self.assertEqual(d, Doc.find_one(d._id))
         d['extra_field'] = 'fail'
         self.assertRaises(ValidationError, d.save)
         del d['extra_field']
@@ -450,7 +450,7 @@ class MongoDocumentTestCase(unittest.TestCase):
         Doc.register(client=client, db='nanotestdb')
         d = Doc(foo=six.binary_type('value \xc3\xbc'), bar=six.u('value \xfc'))
         d.insert()
-        dd = Doc.find_one(_id=d['_id'])
+        dd = Doc.find_one(d['_id'])
         self.assertEqual(type(d['foo']), type(dd['foo']))
         self.assertEqual(type(d['bar']), type(dd['bar']))
         self.assertEqual(dd['foo'].decode('utf-8'), dd['bar'])


### PR DESCRIPTION
`check_spec` was causing incompatibility with `find_one(_id)` calls (workaround was: `find_one({'_id': _id})`.

Fixed.
